### PR TITLE
Ci build test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,9 @@ fusion-studio-extension/src/browser/style/index.css
 # integration test files
 cypress/videos/*
 cypress/screenshots/*
+
+# private
+.notes
+
+# node-gyp
+build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,77 +1,99 @@
 os: linux
-dist: bionic
+dist: xenial
+
 language: node_js
 
-node_js:
-  - "node"
-  - "12"
-  - "10"
+services:
+  - docker
 
-matrix:
-  include:
-    - language: python
-      python: 2.7
-      env:
-        - IMG=existdb/existdb:5.2.0
-        - API_XAR=https://github.com/evolvedbinary/fusion-studio-api/releases/download/0.1.1/fusion-studio-api-0.1.1.xar
-      services:
-        - docker
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - libx11-dev
-            - libxkbfile-dev
-            - libgconf2-4
-      before_install:
-        - docker pull $IMG
-        - docker create  --name exist-ci -p 8080:8080 $IMG
-        - wget $API_XAR
-        - docker cp ./*.xar exist-ci:exist/autodeploy
-        - docker start exist-ci
-        - rm *.xar
-        - sleep 10
-      script:
-        - yarn run cypress run --record
-    - language: python
-      python: 3.8
-      env:
-        - IMG=existdb/existdb:5.2.0
-        - API_XAR=https://github.com/evolvedbinary/fusion-studio-api/releases/download/0.1.1/fusion-studio-api-0.1.1.xar
-      services:
-        - docker
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - libx11-dev
-            - libxkbfile-dev
-            - libgconf2-4
-      before_install:
-        - docker pull $IMG
-        - docker create  --name exist-ci -p 8080:8080 $IMG
-        - wget $API_XAR
-        - docker cp ./*.xar exist-ci:exist/autodeploy
-        - docker start exist-ci
-        - rm *.xar
-        - sleep 10
-      script:
-        - yarn run cypress run --record
-    - os: osx
-      osx_image: xcode12
-      addons:
-        homebrew:
-          packages:
-            - yarn
-    #  - os: windows
+addons:
+  apt:
+    sources:
+       - ubuntu-toolchain-r-test
+    update: true
+    packages:
+      - libx11-dev
+      - libxkbfile-dev
+      - libgconf-2-4
+  homebrew:
+    update: true
+    packages:
+      - yarn
 
 env:
   global:
     - ELECTRON_CACHE=$HOME/.cache/electron
     - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
     - YARN_GPG=no
+
+jobs:
+  include:
+    - name: Ubuntu Xenial (16.04) / NodeJS 10 / Python 2 / Cypress
+      node_js: 10
+      env:
+        - IMG=existdb/existdb:latest
+        - API_XAR=https://github.com/evolvedbinary/fusion-studio-api/releases/download/0.1.1/fusion-studio-api-0.1.1.xar
+      before_install:
+        - python --version
+        - docker pull $IMG
+        - docker create  --name exist-ci -p 8080:8080 $IMG
+        - wget $API_XAR
+        - docker cp ./*.xar exist-ci:exist/autodeploy
+        - docker start exist-ci
+        - rm *.xar
+        - sleep 10
+      script:
+        - yarn run cypress run --record
+
+    - name: Ubuntu Xenial (16.04) / NodeJS 12 / Python 2
+      node_js: 12
+      before_install:
+        - python --version
+
+    - name: Ubuntu Focal (20.04) / NodeJS 10 / Python 3
+      dist: focal
+      node_js: 10
+      before_install:
+        - python --version
+
+    - name: Ubuntu Focal (20.04) / NodeJS 12 / Python 3
+      dist: focal
+      node_js: 12
+      before_install:
+        - python --version
+
+    - name: macOS High Sierra (10.13) / NodeJS 10 / Python 2
+      os: osx
+      osx_image: xcode9.3
+      node_js: 10
+      before_install:
+        - python --version
+
+    - name: macOS Catalina (10.15) / NodeJS 10 / Python 2
+      os: osx
+      osx_image: xcode12
+      node_js: 10
+      before_install:
+        - python --version
+
+    - name: macOS Catalina (10.15) / NodeJS 10 / Python 3
+      os: osx
+      osx_image: xcode12
+      node_js: 10
+      env:
+        - PYTHON=/usr/bin/python3
+      before_install:
+        - $PYTHON --version
+
+  allow_failures:
+    - name: Ubuntu Focal (20.04) / NodeJS 14 / Python 3
+      dist: focal
+      node_js: 14
+      before_install:
+        - python --version
+
+
+    #  - os: windows
 
 install:
   - yarn

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: node_js
 
 node_js:
+  - "node"
+  - "12"
   - "10"
 
 matrix:
   include:
     - os: linux
+      dist: bionic
       env:
         - IMG=existdb/existdb:latest
         - API_XAR=https://github.com/evolvedbinary/fusion-studio-api/releases/download/0.1.0/fusion-studio-api-0.1.0.xar
@@ -30,7 +33,7 @@ matrix:
       script:
         - yarn run cypress run --record
     - os: osx
-      osx_image: xcode11
+      osx_image: xcode12
       addons:
         homebrew:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+os: linux
+dist: bionic
 language: node_js
 
 node_js:
@@ -7,8 +9,33 @@ node_js:
 
 matrix:
   include:
-    - os: linux
-      dist: bionic
+    - language: python
+      python: 2.7
+      env:
+        - IMG=existdb/existdb:5.2.0
+        - API_XAR=https://github.com/evolvedbinary/fusion-studio-api/releases/download/0.1.1/fusion-studio-api-0.1.1.xar
+      services:
+        - docker
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - libx11-dev
+            - libxkbfile-dev
+            - libgconf2-4
+      before_install:
+        - docker pull $IMG
+        - docker create  --name exist-ci -p 8080:8080 $IMG
+        - wget $API_XAR
+        - docker cp ./*.xar exist-ci:exist/autodeploy
+        - docker start exist-ci
+        - rm *.xar
+        - sleep 10
+      script:
+        - yarn run cypress run --record
+    - language: python
+      python: 3.8
       env:
         - IMG=existdb/existdb:5.2.0
         - API_XAR=https://github.com/evolvedbinary/fusion-studio-api/releases/download/0.1.1/fusion-studio-api-0.1.1.xar

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ matrix:
     - os: linux
       dist: bionic
       env:
-        - IMG=existdb/existdb:latest
-        - API_XAR=https://github.com/evolvedbinary/fusion-studio-api/releases/download/0.1.0/fusion-studio-api-0.1.0.xar
+        - IMG=existdb/existdb:5.2.0
+        - API_XAR=https://github.com/evolvedbinary/fusion-studio-api/releases/download/0.1.1/fusion-studio-api-0.1.1.xar
       services:
         - docker
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,16 @@
-os: linux
-dist: xenial
+os:
+  - linux
+  - osx
+dist: focal
+osx_image:
+  - xcode9.3
+  - xcode11
 
 language: node_js
+
+node_js:
+  - 10
+  - 12
 
 services:
   - docker
@@ -25,16 +34,26 @@ env:
     - ELECTRON_CACHE=$HOME/.cache/electron
     - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
     - YARN_GPG=no
+    - PYTHON=/usr/bin/python3
 
 jobs:
+  exclude:
+    - os: osx
+      osx_image: xcode9.3
+      node_js: 12
+    - os: osx
+      osx_image: xcode11
+      node_js: 12
+
   include:
     - name: Ubuntu Xenial (16.04) / NodeJS 10 / Python 2 / Cypress
+      dist: xenial
       node_js: 10
       env:
         - IMG=existdb/existdb:latest
         - API_XAR=https://github.com/evolvedbinary/fusion-studio-api/releases/download/0.1.1/fusion-studio-api-0.1.1.xar
-      before_install:
-        - python --version
+        - PYTHON=/usr/bin/python
+      before_script:
         - docker pull $IMG
         - docker create  --name exist-ci -p 8080:8080 $IMG
         - wget $API_XAR
@@ -42,58 +61,43 @@ jobs:
         - docker start exist-ci
         - rm *.xar
         - sleep 10
-      script:
+      after_success:
         - yarn run cypress run --record
 
     - name: Ubuntu Xenial (16.04) / NodeJS 12 / Python 2
+      env:
+        - PYTHON=/usr/bin/python
+      dist: xenial
       node_js: 12
-      before_install:
-        - python --version
 
-    - name: Ubuntu Focal (20.04) / NodeJS 10 / Python 3
+    - name: Ubuntu Focal (20.04) / NodeJS 14 / Python 3
       dist: focal
-      node_js: 10
-      before_install:
-        - python --version
-
-    - name: Ubuntu Focal (20.04) / NodeJS 12 / Python 3
-      dist: focal
-      node_js: 12
-      before_install:
-        - python --version
-
-    - name: macOS High Sierra (10.13) / NodeJS 10 / Python 2
-      os: osx
-      osx_image: xcode9.3
-      node_js: 10
-      before_install:
-        - python --version
-
-    - name: macOS Catalina (10.15) / NodeJS 10 / Python 2
-      os: osx
-      osx_image: xcode12
-      node_js: 10
-      before_install:
-        - python --version
+      node_js: 14
 
     - name: macOS Catalina (10.15) / NodeJS 10 / Python 3
       os: osx
       osx_image: xcode12
       node_js: 10
-      env:
-        - PYTHON=/usr/bin/python3
-      before_install:
-        - $PYTHON --version
+
+    - name: macOS Catalina (10.15) / NodeJS 12 / Python 3
+      os: osx
+      osx_image: xcode12
+      node_js: 12
 
   allow_failures:
     - name: Ubuntu Focal (20.04) / NodeJS 14 / Python 3
       dist: focal
       node_js: 14
-      before_install:
-        - python --version
+
+    - name: macOS Catalina (10.15) / NodeJS 12 / Python 3
+      os: osx
+      osx_image: xcode12
+      node_js: 12
 
 
-    #  - os: windows
+before_install:
+  - python --version
+  - npm i -g node-gyp
 
 install:
   - yarn
@@ -103,7 +107,7 @@ install:
   - yarn start &
   - cd ..
 
-before_script:
+script:
   - yarn test
 
 before_cache:

--- a/README.md
+++ b/README.md
@@ -14,14 +14,37 @@ If you don't know what Theia is, then you likely want the full [Fusion Studio ID
 *   [Fusion Studio API](https://github.com/evolvedbinary/fusion-studio-api) a compatible exist or fusion database.
 
 #### For building
-*   [Node 10](https://nodejs.org/dist/v10.16.3/). Tested with v10.16.3 (it should be installed with [nvm](https://github.com/nvm-sh/nvm))
-*   [Yarn](https://yarnpkg.com). Tested with v1.17.3 (it should be installed with [nvm](https://github.com/nvm-sh/nvm)).
-*   [Python 2](https://www.python.org/). Tested with 2.7.16
+*   [Node 10](https://nodejs.org/dist/v10.16.3/) `>= 10.16.3` (it should be installed with [nvm](https://github.com/nvm-sh/nvm))
+*   [Yarn](https://yarnpkg.com) `> 1.15.x`(it should be installed with [nvm](https://github.com/nvm-sh/nvm)).
+*   [Python](https://www.python.org/) (it should be installed with [pyenv](https://github.com/pyenv/pyenv))
+    *   Due to upstream constraints from [theia](https://theia-ide.org) we override the inherited hard dependency on Python 2. Systems that ship with python2 pre-installed fusion-studio should continue to build normally
+    *   Build errors with node-gyp are unfortunately common on systems with multiple python installations. On systems that no longer include python2, or on macOS >10.14 we recommend using python 3.8, and configuring the build environment accordingly. The following assumes you used nvm and pyenv to install your desired versions.
+    1.  Make sure your system and shell use the correct python environment:
+        -   ```bash
+            python --version
+            ```
+            It should point to `Python 3.8.x`
+        -   Set an environment variable to force node-gyp to use this version, e.g. `3.8.3`
+            ```bash
+            echo 'export NODE_GYP_FORCE_PYTHON="~/.pyenv/versions/3.8.3/bin/python3"' >> ~/.zshrc
+            ```
+            For bash users replace `.zshrc` with `bashrc`
+    1.  Install node-gyp globally:
+        ```shell
+        npm i -g node-gyp
+        ```           
+        If prompted reinstall or update `npm`.
+    1.  If you are still encountering node-gyp related errors, set npm to always use the global node-gyp installation.
+        ```
+        npm config set node_gyp <path to node-gyp>
+        ```            
 *   Windows platforms only:
     *   Microsoft Visual Studio 2015 C++. Tested with Community Edition
+*   MacOS Catalina only:
+    *   You might have to reinstall Xcode CLI tools, check [Catalina](https://github.com/nodejs/node-gyp/blob/master/macOS_Catalina.md) for a one line acid test, and to help you further debug problems.    
 
 #### For Testing
-*   [cypress.js](https://www.cypress.io) v3.2.0    
+*   [cypress.js](https://www.cypress.io)`>=4.1.0`    
 
 
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "node-sass": "4.14.1"
   },
   "resolutions": {
-  "node-gyp": "^7.0.0"
+  "node-gyp": "^7.0.0",
+  "node-pre-gyp": "^0.15.0"
   },
   "workspaces": [
     "fusion-studio-extension",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "lerna": "3.22.1",
     "node-sass": "4.14.1"
   },
+  "resolutions": {
+  "node-gyp": "^7.0.0"
+  },
   "workspaces": [
     "fusion-studio-extension",
     "browser-app",


### PR DESCRIPTION
this makes the errors i see when trying to build, visible on travis.
Basically if this passes without a glitch ppl should be able to build


`node12` is actively tested on Ubuntu with `python2` and `python3`, these tests are allowed to fail on macOS
see #176 

build errors are gone, readme updated, and we are now testing in clean contemporary environments as well as historic environments. We are also testing against `node14` on linux, and `node12` on macOS catalina to see if upstream changes are creating new build possibilities.

close #174 