### PR TITLE
fix: building electron app

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "homepage": "https://github.com/evolvedbinary/fusion-studio-extension#readme",
   "scripts": {
-    "postinstall": "yarn sass",
+    "postinstall": "yarn sass && yarn workspace electron-app electron-rebuild",
     "sass": "node-sass ./fusion-studio-extension/src/browser/style/index.scss ./fusion-studio-extension/src/browser/style/index.css",
     "sass:watch": "node-sass ./fusion-studio-extension/src/browser/style/index.scss ./fusion-studio-extension/src/browser/style/index.css --watch",
     "prepare": "lerna run prepare",


### PR DESCRIPTION
This fixes a problem that may occur when you try to start `electron-app`, this is the error you get:
```
Error: The module '.../fusion-studio-extension/node_modules/drivelist/build/Release/drivelist.node'
was compiled against a different Node.js version using
NODE_MODULE_VERSION XX. This version of Node.js requires
NODE_MODULE_VERSION YY. Please try re-compiling or re-installing
the module (for instance, using `npm rebuild` or `npm install`).
```