### PR TITLE
We now only support NodeJS 12 (and also test with NodeJS 14)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,15 @@ env:
 
 jobs:
   include:
-    - name: Ubuntu Xenial (16.04) / NodeJS 10 / Python 2 / Cypress
+    - name: Ubuntu Xenial (16.04) / NodeJS 14 / Python 2
       os: linux
       dist: xenial
-      node_js: 10
+      node_js: 14
+
+    - name: Ubuntu Xenial (16.04) / NodeJS 12 / Python 2 / Cypress
+      os: linux
+      dist: xenial
+      node_js: 12
       env:
         - IMG=existdb/existdb:5.2.0
         - API_XAR=https://www.fusiondb.com/download/fusion-studio-api-1.1.1.xar
@@ -44,50 +49,40 @@ jobs:
         - yarn test
         - yarn run cypress run --record
 
-    - name: Ubuntu Xenial (16.04) / NodeJS 12 / Python 2
-      os: linux
-      dist: xenial
-      node_js: 12
-
-    - name: Ubuntu Focal (20.04) / NodeJS 10 / Python 3
+    - name: Ubuntu Focal (20.04) / NodeJS 14 / Python 3
       os: linux
       dist: focal
-      node_js: 10
+      node_js: 14
 
     - name: Ubuntu Focal (20.04) / NodeJS 12 / Python 3
       os: linux
       dist: focal
       node_js: 12
 
-    - name: Ubuntu Focal (20.04) / NodeJS 14 / Python 3
-      os: linux
-      dist: focal
-      node_js: 14
-
-    - name: macOS High Sierra (10.13) / NodeJS 10 / Python 2
+    - name: macOS High Sierra (10.13) / NodeJS 14 / Python 2
       os: osx
       osx_image: xcode9.3
-      node_js: 10
+      node_js: 14
 
     - name: macOS High Sierra (10.13) / NodeJS 12 / Python 2
       os: osx
       osx_image: xcode9.3
       node_js: 12
 
-    - name: macOS Catalina (10.15) / NodeJS 10 / Python 2
+    - name: macOS Catalina (10.15) / NodeJS 14 / Python 2
       os: osx
       osx_image: xcode12
-      node_js: 10
+      node_js: 14
 
     - name: macOS Catalina (10.15) / NodeJS 12 / Python 2
       os: osx
       osx_image: xcode12
       node_js: 12
 
-    - name: macOS Catalina (10.15) / NodeJS 10 / Python 3
+    - name: macOS Catalina (10.15) / NodeJS 14 / Python 3
       os: osx
       osx_image: xcode12
-      node_js: 10
+      node_js: 14
       env:
         - PYTHON=/usr/bin/python3
       before_install:
@@ -101,30 +96,6 @@ jobs:
         - PYTHON=/usr/bin/python3
       before_install:
         - $PYTHON --version
-
-  allow_failures:
-    - name: Ubuntu Focal (20.04) / NodeJS 14 / Python 3
-      os: linux
-      dist: focal
-      node_js: 14
-
-    - name: macOS High Sierra (10.13) / NodeJS 12 / Python 2
-      os: osx
-      osx_image: xcode9.3
-      node_js: 12
-
-    - name: macOS Catalina (10.15) / NodeJS 12 / Python 2
-      os: osx
-      osx_image: xcode12
-      node_js: 12
-
-    - name: macOS Catalina (10.15) / NodeJS 12 / Python 3
-      os: osx
-      osx_image: xcode12
-      node_js: 12
-      env:
-        - PYTHON=/usr/bin/python3
-
 
 before_install:
  - python --version

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ If you don't know what Theia is, then you likely want the full [Fusion Studio ID
 *   [Fusion Studio API](https://github.com/evolvedbinary/fusion-studio-api) installed in a compatible [FusionDB Server](https://www.fusiondb.com) or [eXist-db](https://www.exist-db.org) database.
 
 #### For building
-*   [Node 10](https://nodejs.org/dist/v10.16.3/). `>= 10.16.3` (it should most likely be installed with [nvm](https://github.com/nvm-sh/nvm))
+*   [Node 12](https://nodejs.org/dist/v12.18.3/). `>= 12.18.3` (it should most likely be installed with [nvm](https://github.com/nvm-sh/nvm))
+    * Node 10 may work, and Node 14 should work... however we are focused on Node 12 compatibility.
 *   [Yarn](https://yarnpkg.com). `> 1.15.x` (it can easily be installed globally via npm (Node Package Manager), but you should be aware this has a small [security implication](https://classic.yarnpkg.com/en/docs/install/#install-via-npm). npm is installed when you install Node).
 *   [Python](https://www.python.org/) `>= 2.7.12` or `>= 3.7.7.` (if your system does not provide it, consider using [pyenv](https://github.com/pyenv/pyenv)).
         If you are having trouble building and have multiple versions of Python installed via `pyenv` or any other mechanism, see the [Debugging Python Build Issues](#debugging-python-build-issues) section).
@@ -45,6 +46,7 @@ then the following information may be useful.
 The following commands will install the required packages and setup Python 3 via pyenv on Ubuntu 20.04.
 
 ```
+sudo curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
 sudo apt-get install nodejs yarnpkg libx11-dev libxkbfile-dev
 alias yarn=yarnpkg
 
@@ -67,7 +69,7 @@ The following commands will install the required packages on CentOS 7.
 sudo yum update
 sudo yum install -y libX11-devel libxkbfile-devel
 sudo yum install -y gcc-c++ make
-sudo curl -sL https://rpm.nodesource.com/setup_10.x | sudo bash -
+sudo curl -sL https://rpm.nodesource.com/setup_12.x | sudo bash -
 sudo yum install -y nodejs
 curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | sudo tee /etc/yum.repos.d/yarn.repo
 sudo yum install -y yarn

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,20 +1,19 @@
 version: '{branch}-{build}'
 
 environment:
-  nodejs_version: "10"
+  nodejs_version: "12"
   YARN_GPG: no
 
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu1804
 
 cache:
   - node_modules                        # local npm modules
   - '%APPDATA%\npm-cache'               # npm cache
 
 # used on Ubuntu
-stack: node 10
+stack: node 12
 
 install:
   - cmd: PowerShell.exe "Install-Product node $env:nodejs_version"


### PR DESCRIPTION
* Remove CI targets for NodeJS 10
* Add further NodeJS 14 targets
* Update the README.md for minimum requirements.