### PR TITLE
Api version check

### DIFF
--- a/fusion-studio-extension/src/browser/core.ts
+++ b/fusion-studio-extension/src/browser/core.ts
@@ -309,7 +309,8 @@ export class FSCore {
         if (FSErrorObject.is(error)) {
           FSDialog.alert('New Connection',
             ERROR_MESSAGES[error.code] + ' "' + (error.data?.length && error.data[0]) + '"',
-            'You need to update your API to version "' + API_MINIMUM_VERSION + '" or higher');
+            // TODO: elaborate on the instructions, maybe link to a documentation page
+            'You need to update your API to version "' + API_MINIMUM_VERSION + '" or higher.<br/>Visit <a href="https://fusiondb.com/">Fusion DB website</a> for more information on how to update.');
         } else {
           console.error('not caught:', error);
         }

--- a/fusion-studio-extension/src/browser/dialogs/alert-dialog.ts
+++ b/fusion-studio-extension/src/browser/dialogs/alert-dialog.ts
@@ -18,13 +18,13 @@ export class FSAlertDialog extends AbstractDialog<any> {
     
     const message = document.createElement('p');
     message.className = 'fusion-alert-message';
-    message.innerText = this.props.message;
+    message.innerHTML = this.props.message;
     this.containerDiv.appendChild(message);
     
     if (this.props.secondaryMessage) {
       const secondaryMessage = document.createElement('p');
       secondaryMessage.className = 'fusion-alert-secondary-message';
-      secondaryMessage.innerText = this.props.secondaryMessage;
+      secondaryMessage.innerHTML = this.props.secondaryMessage;
       this.containerDiv.appendChild(secondaryMessage);
     }
     


### PR DESCRIPTION
When Fusion Studio tries to connect to a server with an old (not supported) plugin, it includes instructions on how to update the plugin in the displayed error message